### PR TITLE
Refactoring of the Chain type to allow for missing values

### DIFF
--- a/src/MCMCChain.jl
+++ b/src/MCMCChain.jl
@@ -30,7 +30,7 @@ Parameters:
 - `names`: List of variable names (strings)
 - `chains`: List of chain ids
 """
-struct Chains <: AbstractChains
+struct Chains{T<:Real} <: AbstractChains
     value::Array{Union{Missing, T}, 3}
     range::AbstractRange{Int}
     names::Vector

--- a/src/MCMCChain.jl
+++ b/src/MCMCChain.jl
@@ -31,9 +31,10 @@ Parameters:
 - `chains`: List of chain ids
 """
 struct Chains <: AbstractChains
-    value::Array{Float64, 3}
+    value::Array{Union{Missing, T}, 3}
     range::AbstractRange{Int}
-    names::Vector{AbstractString}
+    names::Vector
+    uniquenames::Dict{Symbol, Int}
     chains::Vector{Int}
 end
 

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -22,7 +22,7 @@ function Chains(
                 thin = 1,
                 names = AbstractString[], 
                 chains = Int[]
-               ) where {T<:Real}
+               ) where {T<:Union{Real, Missing}}
 
     n, p, m = size(value)
 
@@ -48,7 +48,7 @@ function Chains(
                 thin = 1,
                 names = AbstractString[],
                 chains = 1
-               ) where {T<:Real}
+               ) where {T<:Union{Real, Missing}}
 
     Chains(
         reshape(value, size(value, 1), size(value, 2), 1), 
@@ -65,7 +65,7 @@ function Chains(
                 thin = 1,
                 names = "Param#1",
                 chains = 1
-               ) where {T<:Real}
+               ) where {T<:Union{Real, Missing}}
     Chains(
          reshape(value, length(value), 1, 1),
          start=start,

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -2,47 +2,77 @@
 
 #################### Constructors ####################
 
-function Chains(iters::Integer, params::Integer;
-               start::Integer=1, thin::Integer=1, chains::Integer=1,
-               names::Vector{T}=AbstractString[]) where {T <: AbstractString}
-  value = Array{Float64}(length(start:thin:iters), params, chains)
-  fill!(value, NaN)
-  Chains(value, start=start, thin=thin, names=names)
+function Chains(
+                iters::Int,
+                params::Int;
+                start = 1,
+                thin = 1,
+                chains = 1,
+                names = AbstractString[]
+               )
+    value = ones(length(start:thin:iters), params, chains)
+    fill!(value, NaN)
+
+    Chains(value, start=start, thin=thin, names=names)
 end
 
-function Chains(value::Array{T, 3};
-               start::Integer=1, thin::Integer=1,
-               names::Vector{U}=AbstractString[], chains::Vector{V}=Int[]) where {T<:Real, U<:AbstractString, V<:Integer}
-  n, p, m = size(value)
+function Chains(
+                value::Array{T, 3};
+                start = 1,
+                thin = 1,
+                names = AbstractString[], 
+                chains = Int[]
+               ) where {T<:Real}
 
-  if isempty(names)
-    names = map(i -> "Param$i", 1:p)
-  elseif length(names) != p
-    throw(DimensionMismatch("size(value, 2) and names length differ"))
-  end
+    n, p, m = size(value)
 
-  if isempty(chains)
-    chains = collect(1:m)
-  elseif length(chains) != m
-    throw(DimensionMismatch("size(value, 3) and chains length differ"))
-  end
+    if isempty(names)
+        names = map(i -> "Param#$i", 1:p)
+    elseif length(names) != p
+        throw(DimensionMismatch("size(value, 2) and names length differ"))
+    end
 
-  v = convert(Array{Float64, 3}, value)
-  Chains(v, range(start, step = thin, length = n), AbstractString[names...], Int[chains...])
+    if isempty(chains)
+        chains = collect(1:m)
+    elseif length(chains) != m
+        throw(DimensionMismatch("size(value, 3) and chains length differ"))
+    end
+
+    v = convert(Array{Union{Missing, Real}, 3}, value)
+    Chains(v, range(start, step = thin, length = n), names, chains)
 end
 
-function Chains(value::Matrix{T};
-               start::Integer=1, thin::Integer=1,
-               names::Vector{U}=AbstractString[], chains::Integer=1) where {T<:Real, U<:AbstractString}
-  Chains(reshape(value, size(value, 1), size(value, 2), 1), start=start,
-         thin=thin, names=names, chains=Int[chains])
+function Chains(
+                value::Matrix{T};
+                start = 1,
+                thin = 1,
+                names = AbstractString[],
+                chains = 1
+               ) where {T<:Real}
+
+    Chains(
+        reshape(value, size(value, 1), size(value, 2), 1), 
+        start=start,
+        thin=thin,
+        names=names,
+        chains=Int[chains]
+    )
 end
 
-function Chains(value::Vector{T};
-               start::Integer=1, thin::Integer=1,
-               names::AbstractString="Param1", chains::Integer=1) where {T<:Real}
-  Chains(reshape(value, length(value), 1, 1), start=start, thin=thin,
-         names=AbstractString[names], chains=Int[chains])
+function Chains(
+                value::Vector{T};
+                start = 1,
+                thin = 1,
+                names = "Param#1",
+                chains = 1
+               ) where {T<:Real}
+    Chains(
+         reshape(value, length(value), 1, 1),
+         start=start,
+         thin=thin,
+         names=AbstractString[names],
+         chains=Int[chains]
+    )
 end
 
 

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -8,12 +8,13 @@ function Chains(
                 start = 1,
                 thin = 1,
                 chains = 1,
-                names = AbstractString[]
+                names = AbstractString[],
+                uniquenames = Dict{Symbol, Int}()
                )
     value = ones(length(start:thin:iters), params, chains)
     fill!(value, NaN)
 
-    Chains(value, start=start, thin=thin, names=names)
+    Chains(value, start=start, thin=thin, names=names, uniquenames = uniquenames)
 end
 
 function Chains(
@@ -21,6 +22,7 @@ function Chains(
                 start = 1,
                 thin = 1,
                 names = AbstractString[], 
+                uniquenames = Dict{Symbol, Int}(),
                 chains = Int[]
                ) where {T<:Union{Real, Missing}}
 
@@ -31,6 +33,12 @@ function Chains(
     elseif length(names) != p
         throw(DimensionMismatch("size(value, 2) and names length differ"))
     end
+    
+    if isempty(uniquenames)
+        uniquenames = Dict(gensym() => i for i in 1:p)
+    elseif length(uniquenames) != p
+        throw(DimensionMismatch("size(value, 2) and uniquenames length differ"))
+    end
 
     if isempty(chains)
         chains = collect(1:m)
@@ -39,7 +47,7 @@ function Chains(
     end
 
     v = convert(Array{Union{Missing, Real}, 3}, value)
-    Chains(v, range(start, step = thin, length = n), names, chains)
+    Chains(v, range(start, step = thin, length = n), names, uniquenames, chains)
 end
 
 function Chains(
@@ -47,6 +55,7 @@ function Chains(
                 start = 1,
                 thin = 1,
                 names = AbstractString[],
+                uniquenames = Dict{Symbol, Int}(),
                 chains = 1
                ) where {T<:Union{Real, Missing}}
 
@@ -55,6 +64,7 @@ function Chains(
         start=start,
         thin=thin,
         names=names,
+        uniquenames = uniquenames,
         chains=Int[chains]
     )
 end
@@ -64,6 +74,7 @@ function Chains(
                 start = 1,
                 thin = 1,
                 names = "Param#1",
+                uniquenames = gensym(),
                 chains = 1
                ) where {T<:Union{Real, Missing}}
     Chains(
@@ -71,6 +82,7 @@ function Chains(
          start=start,
          thin=thin,
          names=AbstractString[names],
+         uniquenames = Dict{Symbol, Int}(uniquenames => 1),
          chains=Int[chains]
     )
 end

--- a/src/discretediag.jl
+++ b/src/discretediag.jl
@@ -419,6 +419,8 @@ end
 function discretediag(c::AbstractChains; frac::Real=0.3, 
                       method::Symbol=:weiss, nsim::Int=1000)
 
+    @assert !any(ismissing.(c.value)) "Diagnostic doesn't support missing values"
+
   num_iters, num_vars, num_chains = size(c.value)
 
   valid_methods = [:hangartner, :weiss, :DARBOOT,

--- a/src/gelmandiag.jl
+++ b/src/gelmandiag.jl
@@ -2,7 +2,10 @@
 
 function gelmandiag(c::AbstractChains; alpha::Real=0.05, mpsrf::Bool=false,
                     transform::Bool=false)
-  n, p, m = size(c.value)
+  
+    @assert !any(ismissing.(c.value)) "Gelman diagnostics doesn't support missing values"
+    
+    n, p, m = size(c.value)
   m >= 2 ||
     throw(ArgumentError("less than 2 chains supplied to gelman diagnostic"))
 

--- a/src/gewekediag.jl
+++ b/src/gewekediag.jl
@@ -19,6 +19,7 @@ end
 
 function gewekediag(c::AbstractChains; first::Real=0.1, last::Real=0.5,
                     etype=:imse, args...)
+
     _, p, m = size(c.value)
     vals = Array{Float64}(undef, p, 2, m)
     for j in 1:p, k in 1:m

--- a/src/gewekediag.jl
+++ b/src/gewekediag.jl
@@ -19,13 +19,18 @@ end
 
 function gewekediag(c::AbstractChains; first::Real=0.1, last::Real=0.5,
                     etype=:imse, args...)
-  _, p, m = size(c.value)
-  vals = Array{Float64}(undef, p, 2, m)
-  for j in 1:p, k in 1:m
-    vals[j, :, k] = gewekediag(c.value[:, j, k], first=first, last=last,
-                               etype=etype; args...)
-  end
-  hdr = header(c) * "\nGeweke Diagnostic:\nFirst Window Fraction = $first\n" *
+    _, p, m = size(c.value)
+    vals = Array{Float64}(undef, p, 2, m)
+    for j in 1:p, k in 1:m
+        vals[j, :, k] = gewekediag(
+                            collect(skipmissing(c.value[:, j, k])),
+                            first=first,
+                            last=last,
+                            etype=etype;
+                            args...
+                        )
+    end
+    hdr = header(c) * "\nGeweke Diagnostic:\nFirst Window Fraction = $first\n" *
         "Second Window Fraction = $last\n"
-  ChainSummary(vals, c.names, ["Z-score", "p-value"], hdr)
+    ChainSummary(vals, c.names, ["Z-score", "p-value"], hdr)
 end

--- a/src/heideldiag.jl
+++ b/src/heideldiag.jl
@@ -26,13 +26,23 @@ function heideldiag(x::Vector{T}; alpha::Real=0.05, eps::Real=0.1,
   [i + start - 2, converged, round(pvalue, digits = 4), ybar, halfwidth, passed]
 end
 
-function heideldiag(c::AbstractChains; alpha::Real=0.05, eps::Real=0.1,
-                    etype=:imse, args...)
-  _, p, m = size(c.value)
-  vals = Array{Float64}(undef, p, 6, m)
-  for j in 1:p, k in 1:m
-    vals[j, :, k] = heideldiag(c.value[:, j, k], alpha=alpha, eps=eps,
-                               etype=etype, start=first(c.range); args...)
+function heideldiag(c::AbstractChains;
+                    alpha = 0.05,
+                    eps = 0.1,
+                    etype = :imse,
+                    args...
+                   )
+    _, p, m = size(c.value)
+    vals = Array{Float64}(undef, p, 6, m)
+    for j in 1:p, k in 1:m
+        vals[j, :, k] = heideldiag(
+                            collect(skipmissing(c.value[:, j, k])),
+                            alpha=alpha,
+                            eps=eps,
+                            etype=etype,
+                            start=first(c.range);
+                            args...
+                           )
   end
   hdr = header(c) * "\nHeidelberger and Welch Diagnostic:\n" *
         "Target Halfwidth Ratio = $eps\nAlpha = $alpha\n"

--- a/src/mcse.jl
+++ b/src/mcse.jl
@@ -8,14 +8,15 @@ function mcse(x::Vector{T}, method::Symbol=:imse; args...) where {T<:Real}
 end
 
 function mcse_bm(x::Vector{T}; size::Integer=100) where {T<:Real}
-  n = length(x)
-  m = div(n, size)
-  m >= 2 ||
-    throw(ArgumentError(
-      "iterations are < $(2 * size) and batch size is > $(div(n, 2))"
-    ))
-  mbar = [mean(x[i * size .+ (1:size)]) for i in 0:(m - 1)]
-  sem(mbar)
+    n = length(x)
+    m = div(n, size)
+    if m < 2
+        throw(
+         ArgumentError("iterations are < $(2 * size) and batch size is > $(div(n, 2))")
+        )
+    end
+    mbar = [mean(x[i * size .+ (1:size)]) for i in 0:(m - 1)]
+    return sem(mbar)
 end
 
 function mcse_imse(x::Vector{T}) where {T<:Real}

--- a/src/mcse.jl
+++ b/src/mcse.jl
@@ -19,28 +19,30 @@ function mcse_bm(x::Vector{T}; size::Integer=100) where {T<:Real}
 end
 
 function mcse_imse(x::Vector{T}) where {T<:Real}
-  n = length(x)
-  m = div(n - 2, 2)
-  ghat = autocov(x, [0, 1])
-  Ghat = sum(ghat)
-  value = -ghat[1] + 2 * Ghat
-  for i in 1:m
-    Ghat = min(Ghat, sum(autocov(x, [2 * i, 2 * i + 1])))
-    Ghat > 0 || break
-    value += 2 * Ghat
-  end
-  sqrt(value / n)
+    n = length(x)
+    m = div(n - 2, 2)
+    x_ = map(Float64, x)
+    ghat = autocov(x_, [0, 1])
+    Ghat = sum(ghat)
+    value = -ghat[1] + 2 * Ghat
+    for i in 1:m
+        Ghat = min(Ghat, sum(autocov(x_, [2 * i, 2 * i + 1])))
+        Ghat > 0 || break
+        value += 2 * Ghat
+    end
+    return sqrt(value / n)
 end
 
 function mcse_ipse(x::Vector{T}) where {T<:Real}
-  n = length(x)
-  m = div(n - 2, 2)
-  ghat = autocov(x, [0, 1])
-  value = ghat[1] + 2 * ghat[2]
-  for i in 1:m
-    Ghat = sum(autocov(x, [2 * i, 2 * i + 1]))
-    Ghat > 0 || break
-    value += 2 * Ghat
-  end
-  sqrt(value / n)
+    n = length(x)
+    m = div(n - 2, 2)
+    x_ = map(Float64, x)
+    ghat = autocov(x_, [0, 1])
+    value = ghat[1] + 2 * ghat[2]
+    for i in 1:m
+        Ghat = sum(autocov(x_, [2 * i, 2 * i + 1]))
+        Ghat > 0 || break
+        value += 2 * Ghat
+    end
+    return sqrt(value / n)
 end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -68,11 +68,13 @@ end
     if colordim == :parameter
         title := "Chain $(c.chains[i])"
         labels := c.names
-        c.value[:, :, i]
+        nvars = size(c)[2]
+        [collect(skipmissing(c.value[:, k, i])) for k in 1:nvars]
     else
         title := c.names[i]
         labels := map(k -> "Chain $(c.chains[k])", 1:size(c)[3])
-        c.value[:, i, :]
+        nchains = size(c)[3]
+        [collect(skipmissing(c.value[:, i, k])) for k in 1:nchains]
     end
 end
 
@@ -87,11 +89,13 @@ end
     if colordim == :parameter
         title := "Chain $(c.chains[i])"
         labels := c.names
-        c.value[:, :, i]
+        nvars = size(c)[2]
+        [collect(skipmissing(c.value[:, k, i])) for k in 1:nvars]
     else
         title := c.names[i]
         labels := map(k -> "Chain $(c.chains[k])", 1:size(c)[3])
-        c.value[:, i, :]
+        nchains = size(c)[3]
+        [collect(skipmissing(c.value[:, i, k])) for k in 1:nchains]
     end
 end
 
@@ -126,14 +130,16 @@ end
     if colordim == :parameter
         title := "Chain $(c.chains[i])"
         labels := c.names
-        c.value[:, :, i]
+        nvars = size(c)[2]
+        [collect(skipmissing(c.value[:, k, i])) for k in 1:nvars]
     else
         seriestype := discrete[i] ? :histogram : :density
         yaxis := discrete[i] ? "Frequency" : "Density"
         fillalpha := discrete[i] ? 0.7 : 1.0
         title := c.names[i]
         labels := map(k -> "Chain $(c.chains[k])", 1:size(c)[3])
-        c.value[:, i, :]
+        nchains = size(c)[3]
+        [collect(skipmissing(c.value[:, i, k])) for k in 1:nchains]
     end
 end
 

--- a/src/rafterydiag.jl
+++ b/src/rafterydiag.jl
@@ -8,47 +8,47 @@ function rafterydiag(
                      eps = 0.001,
                      range = 1:length(x)
                     ) where {T<:Real}
-  nx = length(x)
-  phi = sqrt(2.0) * erfinv(s)
-  nmin = ceil(Int, q * (1.0 - q) * (phi / r)^2)
-  if nmin > nx
-    @warn "At least $nmin samples are needed for specified q, r, and s"
-    kthin = burnin = total = NaN
-  else
-    dichot = Int[(x .<= quantile(x, q))...]
-    kthin = 0
-    bic = 1.0
-    local test, ntest
-    while bic >= 0.0
-      kthin += 1
-      test = dichot[1:kthin:nx]
-      ntest = length(test)
-      temp = test[1:(ntest - 2)] + 2 * test[2:(ntest - 1)] + 4 * test[3:ntest]
-      trantest = reshape(counts(temp, 0:7), 2, 2, 2)
-      g2 = 0.0
-      for i1 in 1:2, i2 in 1:2, i3 in 1:2
-        tt = trantest[i1, i2, i3]
-        if tt > 0
-          fitted = sum(trantest[:, i2, i3]) * sum(trantest[i1, i2, :]) /
-                   sum(trantest[:, i2, :])
-          g2 += 2.0 * tt * log(tt / fitted)
+
+    nx = length(x)
+    phi = sqrt(2.0) * erfinv(s)
+    nmin = ceil(Int, q * (1.0 - q) * (phi / r)^2)
+    if nmin > nx
+        @warn "At least $nmin samples are needed for specified q, r, and s"
+        kthin = burnin = total = NaN
+    else
+        dichot = Int[(x .<= quantile(x, q))...]
+        kthin = 0
+        bic = 1.0
+        local test, ntest
+        while bic >= 0.0
+            kthin += 1
+            test = dichot[1:kthin:nx]
+            ntest = length(test)
+            temp = test[1:(ntest - 2)] + 2 * test[2:(ntest - 1)] + 4 * test[3:ntest]
+            trantest = reshape(counts(temp, 0:7), 2, 2, 2)
+            g2 = 0.0
+            for i1 in 1:2, i2 in 1:2, i3 in 1:2
+                tt = trantest[i1, i2, i3]
+                if tt > 0
+                    fitted = sum(trantest[:, i2, i3]) * sum(trantest[i1, i2, :]) / 
+                        sum(trantest[:, i2, :])
+                    g2 += 2.0 * tt * log(tt / fitted)
+                end
+            end
+            bic = g2 - 2.0 * log(ntest - 2.0)
         end
-      end
-      bic = g2 - 2.0 * log(ntest - 2.0)
+
+        tranfinal = counts(test[1:(ntest - 1)] + 2 * test[2:ntest], 0:3)
+        alpha = tranfinal[3] / (tranfinal[1] + tranfinal[3])
+        beta = tranfinal[2] / (tranfinal[2] + tranfinal[4])
+        kthin *= step(range)
+        m = log(eps * (alpha + beta) / max(alpha, beta)) / log(abs(1.0 - alpha - beta))
+        burnin = kthin * ceil(m) + first(range) - 1
+        n = ((2.0 - alpha - beta) * alpha * beta * phi^2) / (r^2 * (alpha + beta)^3)
+        keep = kthin * ceil(n)
+        total = burnin + keep
     end
-    tranfinal = counts(test[1:(ntest - 1)] + 2 * test[2:ntest], 0:3)
-    alpha = tranfinal[3] / (tranfinal[1] + tranfinal[3])
-    beta = tranfinal[2] / (tranfinal[2] + tranfinal[4])
-    kthin *= step(range)
-    m = log(eps * (alpha + beta) / max(alpha, beta)) /
-        log(abs(1.0 - alpha - beta))
-    burnin = kthin * ceil(m) + start(range) - 1
-    n = ((2.0 - alpha - beta) * alpha * beta * phi^2) /
-        (r^2 * (alpha + beta)^3)
-    keep = kthin * ceil(n)
-    total = burnin + keep
-  end
-  [kthin, burnin, total, nmin, total / nmin]
+    return [kthin, burnin, total, nmin, total / nmin]
 end
 
 function rafterydiag(
@@ -58,7 +58,7 @@ function rafterydiag(
                      s = 0.95,
                      eps = 0.001
                     )
-    _, p, m = size(c.value)
+     _, p, m = size(c.value)
     vals = Array{Float64}(undef, p, 5, m)
     for j in 1:p, k in 1:m
         vals[j, :, k] = rafterydiag(
@@ -71,8 +71,12 @@ function rafterydiag(
         )
     end
 
-    hdr = header(c) * "\nRaftery and Lewis Diagnostic:\n" *
+    hdr = header(c) * "\nRaftery and Lewis Diagnostic:\n" * 
         "Quantile (q) = $q\nAccuracy (r) = $r\nProbability (s) = $s\n"
-  ChainSummary(vals, c.names, ["Thinning", "Burn-in", "Total", "Nmin",
-                               "Dependence Factor"], hdr)
+
+    return ChainSummary(vals,
+                        c.names,
+                        ["Thinning", "Burn-in", "Total", "Nmin", "Dependence Factor"],
+                        hdr
+    )
 end

--- a/src/rafterydiag.jl
+++ b/src/rafterydiag.jl
@@ -1,8 +1,13 @@
 #################### Raftery and Lewis Diagnostic ####################
 
-function rafterydiag(x::Vector{T}; q::Real=0.025, r::Real=0.005,
-                              s::Real=0.95, eps::Real=0.001,
-                              range::AbstractRange=1:length(x)) where {T<:Real}
+function rafterydiag(
+                     x::Vector{T};
+                     q = 0.025,
+                     r = 0.005,
+                     s = 0.95,
+                     eps = 0.001,
+                     range = 1:length(x)
+                    ) where {T<:Real}
   nx = length(x)
   phi = sqrt(2.0) * erfinv(s)
   nmin = ceil(Int, q * (1.0 - q) * (phi / r)^2)
@@ -46,15 +51,27 @@ function rafterydiag(x::Vector{T}; q::Real=0.025, r::Real=0.005,
   [kthin, burnin, total, nmin, total / nmin]
 end
 
-function rafterydiag(c::AbstractChains; q::Real=0.025, r::Real=0.005,
-                     s::Real=0.95, eps::Real=0.001)
-  _, p, m = size(c.value)
-  vals = Array{Float64}(undef, p, 5, m)
-  for j in 1:p, k in 1:m
-    vals[j, :, k] = rafterydiag(c.value[:, j, k], q=q, r=r, s=s, eps=eps,
-                                range=c.range)
-  end
-  hdr = header(c) * "\nRaftery and Lewis Diagnostic:\n" *
+function rafterydiag(
+                     c::AbstractChains;
+                     q = 0.025,
+                     r = 0.005,
+                     s = 0.95,
+                     eps = 0.001
+                    )
+    _, p, m = size(c.value)
+    vals = Array{Float64}(undef, p, 5, m)
+    for j in 1:p, k in 1:m
+        vals[j, :, k] = rafterydiag(
+            collect(skipmissing(c.value[:, j, k])),
+            q=q,
+            r=r,
+            s=s,
+            eps=eps,
+            range=c.range
+        )
+    end
+
+    hdr = header(c) * "\nRaftery and Lewis Diagnostic:\n" *
         "Quantile (q) = $q\nAccuracy (r) = $r\nProbability (s) = $s\n"
   ChainSummary(vals, c.names, ["Thinning", "Burn-in", "Total", "Nmin",
                                "Dependence Factor"], hdr)

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -1,5 +1,4 @@
 #################### Posterior Statistics ####################
-
 function autocor(c::AbstractChains; 
                  lags::Vector=[1, 5, 10, 50],
                  relative::Bool=true)
@@ -26,14 +25,17 @@ function autocor(c::AbstractChains;
 end
 
 function cor(c::AbstractChains)
-    ChainSummary(cor(combine(c)), c.names, c.names, header(c))
+    return ChainSummary(cor(combine(c)), c.names, c.names, header(c))
 end
 
 function changerate(c::AbstractChains)
+
+    @assert !any(ismissing.(c.value)) "Change rate comp. doesn't support missing values."
+
     n, p, m = size(c.value)
     r = zeros(Float64, p, 1, 1)
     r_mv = 0.0
-    delta = Array{Bool}(p)
+    delta = Array{Bool}(undef, p)
     for k in 1:m
         prev = c.value[1, :, k]
         for i in 2:n
@@ -47,61 +49,73 @@ function changerate(c::AbstractChains)
             r_mv += any(delta)
         end
     end
-    vals = round.([r; r_mv] / (m * (n - 1)), 3)
-    ChainSummary(vals, [c.names; "Multivariate"], ["Change Rate"], header(c))
+    vals = round.([r; r_mv] / (m * (n - 1)), digits = 3)
+    return ChainSummary(vals, [c.names; "Multivariate"], ["Change Rate"], header(c))
 end
 
 describe(c::AbstractChains; args...) = describe(stdout, c; args...)
 
-function describe(io::IO, c::AbstractChains;
-                  q::Vector=[0.025, 0.25, 0.5, 0.75, 0.975], etype=:bm, args...)
-  ps_stats = summarystats(c; etype=etype, args...)
-  ps_quantiles = quantile(c, q=q)
-  println(io, ps_stats.header)
-  print(io, "Empirical Posterior Estimates:\n")
-  show(io, ps_stats)
-  print(io, "Quantiles:\n")
-  show(io, ps_quantiles)
+function describe(io::IO, 
+                  c::AbstractChains;
+                  q = [0.025, 0.25, 0.5, 0.75, 0.975],
+                  etype=:bm,
+                  args...
+                 )
+    ps_stats = summarystats(c; etype=etype, args...)
+    ps_quantiles = quantile(c, q=q)
+    println(io, ps_stats.header)
+    print(io, "Empirical Posterior Estimates:\n")
+    show(io, ps_stats)
+    print(io, "Quantiles:\n")
+    show(io, ps_quantiles)
+
+    return ps_stats, ps_quantiles
 end
 
 function hpd(x::Vector{T}; alpha::Real=0.05) where {T<:Real}
-  n = length(x)
-  m = max(1, ceil(Int, alpha * n))
+    n = length(x)
+    m = max(1, ceil(Int, alpha * n))
 
-  y = sort(x)
-  a = y[1:m]
-  b = y[(n - m + 1):n]
-  _, i = findmin(b - a)
+    y = sort(x)
+    a = y[1:m]
+    b = y[(n - m + 1):n]
+    _, i = findmin(b - a)
 
-  [a[i], b[i]]
+    return [a[i], b[i]]
 end
 
 function hpd(c::AbstractChains; alpha::Real=0.05)
-  pct = first(showoff([100.0 * (1.0 - alpha)]))
-  labels = ["$(pct)% Lower", "$(pct)% Upper"]
-  vals = permutedims(
-    mapslices(x -> hpd(vec(x), alpha=alpha), c.value, dims = [1, 3]),
-    [2, 1, 3]
-  )
-  ChainSummary(vals, c.names, labels, header(c))
+    pct = first(showoff([100.0 * (1.0 - alpha)]))
+    labels = ["$(pct)% Lower", "$(pct)% Upper"]
+    vals = permutedims(
+        mapslices(x -> hpd(collect(skipmissing(x)), alpha=alpha), c.value, dims = [1, 3]),
+        [2, 1, 3]
+    )
+    return ChainSummary(vals, c.names, labels, header(c))
 end
 
 function quantile(c::AbstractChains; q::Vector=[0.025, 0.25, 0.5, 0.75, 0.975])
-  labels = map(x -> string(100 * x) * "%", q)
-  vals = permutedims(
-    mapslices(x -> quantile(vec(x), q), c.value, dims = [1, 3]),
-    [2, 1, 3]
-  )
-  ChainSummary(vals, c.names, labels, header(c))
+    labels = map(x -> string(100 * x) * "%", q)
+    vals = permutedims(
+        mapslices(x -> quantile(collect(skipmissing(x)), q), c.value, dims = [1, 3]),
+        [2, 1, 3]
+    )
+    return ChainSummary(vals, c.names, labels, header(c))
 end
 
 function summarystats(c::AbstractChains; etype=:bm, args...)
-  f = x -> [mean(x), std(x), sem(x), mcse(vec(x), etype; args...)]
-  labels = ["Mean", "SD", "Naive SE", "MCSE", "ESS"]
-  vals = permutedims(
-    mapslices(x -> f(x), c.value, dims =  [1, 3]),
-    [2, 1, 3]
-  )
-  stats = [vals  min.((vals[:, 2] ./ vals[:, 4]).^2, size(c.value, 1))]
-  ChainSummary(stats, c.names, labels, header(c))
+    f = x -> [
+            mean(x),
+            std(x),
+            sem(x),
+            mcse(x, etype; args...)
+    ]
+
+    labels = ["Mean", "SD", "Naive SE", "MCSE", "ESS"]
+    vals = permutedims(
+        mapslices(x -> f(collect(skipmissing(x))), c.value, dims =  [1, 3]),
+        [2, 1, 3]
+    )
+    stats = [vals  min.((vals[:, 2] ./ vals[:, 4]).^2, size(c.value, 1))]
+    return ChainSummary(stats, c.names, labels, header(c))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,71 +1,18 @@
-#################### Model Expression Operators ####################
-
-# function modelfx(literalargs::Vector{Tuple{Symbol, DataType}}, f::Function)
-#   modelfxsrc(literalargs, f)[1]
-# end
-#
-# function modelfxsrc(literalargs::Vector{Tuple{Symbol, DataType}}, f::Function)
-#   args = Expr(:tuple, map(arg -> Expr(:(::), arg[1], arg[2]), literalargs)...)
-#   expr, src = modelexprsrc(f, literalargs)
-#   fx = eval(Main, Expr(:function, args, expr))
-#   (fx, src)
-# end
-#
-#
-# function modelexprsrc(f::Function, literalargs::Vector{Tuple{Symbol, DataType}})
-#   m = first(methods(f).ms)
-#   argnames = Vector{Any}(m.nargs)
-#   ccall(:jl_fill_argnames, Void, (Any, Any), m.source, argnames)
-#
-#   fkeys = Symbol[argnames[2:end]...]
-#   ftypes = DataType[m.sig.parameters[2:end]...]
-#   n = length(fkeys)
-#
-#   literalinds = Int[]
-#   for (key, T) in literalargs
-#     i = findfirst(fkey -> fkey == key, fkeys)
-#     if i != 0 && ftypes[i] == T
-#       push!(literalinds, i)
-#     end
-#   end
-#   nodeinds = setdiff(1:n, literalinds)
-#
-#   all(T -> T == Any, ftypes[nodeinds]) ||
-#     throw(ArgumentError("model node arguments are not all of type Any"))
-#
-#   modelargs = Array{Any}(n)
-#   for i in nodeinds
-#     modelargs[i] = Expr(:ref, :model, QuoteNode(fkeys[i]))
-#   end
-#   for i in literalinds
-#     modelargs[i] = fkeys[i]
-#   end
-#   expr = Expr(:block, Expr(:(=), :f, f), Expr(:call, :f, modelargs...))
-#
-#   (expr, fkeys[nodeinds])
-# end
-
-
 #################### Mathematical Operators ####################
 
-isprobvec(p::AbstractVector) = isprobvec(convert(Vector{Float64}, p))
-
-cummean(x::AbstractArray) = mapslices(cummean, x, dims = [1])
-
-function cummean(x::AbstractVector{T}) where T<:Real
-  y = similar(x, Float64)
-  xs = 0.0
-  for i in 1:length(x)
-    xs += x[i]
-    y[i] = xs / i
-  end
-  y
+function cummean(x::AbstractArray{T}) where T<:Real
+    return mapslices(cummean, x, dims = [1])
 end
 
-# dot(x) = dot(x, x)
-
-# logit(x::Real) = log(x / (1.0 - x))
-# invlogit(x::Real) = 1.0 / (exp(-x) + 1.0)
+function cummean(x::AbstractVector{T}) where T<:Real
+    y = similar(x, T)
+    xs = zero(T)
+    for i in 1:length(x)
+        xs += x[i]
+        y[i] = xs / i
+    end
+    return y
+end
 
 ## Csorgo S and Faraway JJ. The exact and asymptotic distributions of the
 ## Cramer-von Mises statistic. Journal of the Royal Statistical Society,
@@ -79,20 +26,3 @@ function pcramer(q::Real)
   end
   p / (pi^1.5 * sqrt(q))
 end
-
-
-#################### Auxiliary Functions ####################
-
-# ## pmap2 is a partial work-around for the pmap issue in julia 0.4.0 of worker
-# ## node errors being blocked.  In single-processor mode, pmap2 calls map
-# ## instead to avoid the error handling issue.  In multi-processor mode, pmap is
-# ## called and will apply its error processing.
-#
-# function pmap2(f::Function, lsts::AbstractArray)
-#   if (nprocs() > 1)
-#     @everywhere importall Mamba
-#     pmap(f, lsts)
-#   else
-#     map(f, lsts)
-#   end
-# end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,6 @@
 #################### Mathematical Operators ####################
 
-function cummean(x::AbstractArray{T}) where T<:Real
+function cummean(x::AbstractArray) where T<:Real
     return mapslices(cummean, x, dims = [1])
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,15 +1,21 @@
 #################### Mathematical Operators ####################
 
-function cummean(x::AbstractArray) where T<:Real
-    return mapslices(cummean, x, dims = [1])
+function cummean(x::AbstractArray)
+    return mapslices(cummean, x, dims = 1)
 end
 
-function cummean(x::AbstractVector{T}) where T<:Real
-    y = similar(x, T)
-    xs = zero(T)
+function cummean(x::AbstractVector)
+    y = similar(x, Float64)
+    xs = 0.0
+    fill!(y, xs)
+
+    c = 0
     for i in 1:length(x)
-        xs += x[i]
-        y[i] = xs / i
+        if !ismissing(x[i])
+            c += 1
+            xs += x[i]
+        end
+        y[i] = xs / c
     end
     return y
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,4 @@
 #################### Mathematical Operators ####################
-
 function cummean(x::AbstractArray)
     return mapslices(cummean, x, dims = 1)
 end
@@ -24,11 +23,11 @@ end
 ## Cramer-von Mises statistic. Journal of the Royal Statistical Society,
 ## Series B, 58: 221-234, 1996.
 function pcramer(q::Real)
-  p = 0.0
-  for k in 0:3
-    c1 = 4.0 * k + 1.0
-    c2 = c1^2 / (16.0 * q)
-    p += gamma(k + 0.5) / factorial(k) * sqrt(c1) * exp(-c2) * besselk(0.25, c2)
-  end
-  p / (pi^1.5 * sqrt(q))
+    p = 0.0
+    for k in 0:3
+        c1 = 4.0 * k + 1.0
+        c2 = c1^2 / (16.0 * q)
+        p += gamma(k + 0.5) / factorial(k) * sqrt(c1) * exp(-c2) * besselk(0.25, c2)
+    end
+    return p / (pi^1.5 * sqrt(q))
 end

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -15,35 +15,32 @@ val = hcat(val, rand(1:2, n_iter, 1, n_chain))
 chn = Chains(val, start = 1, thin = 2)
 
 @testset "basic chains functions" begin
-  @test first(chn) == 1
-  @test step(chn) == 2
-  @test last(chn) == 999
-  @test size(chn) == (999, 4, 2)
-  @test keys(chn) == ["Param1", "Param2", "Param3", "Param4"]
-  @test isa(chn[:,1,:], MCMCChain.AbstractChains)
-  @test length(vec(chn[:,1,:].value)) == n_chain * n_iter
-  @test all(chn[:,1,1].value .== val[:,1,1])
-  @test all(chn[:,1,2].value .== val[:,1,2])
-  @test all(MCMCChain.indiscretesupport(chn) .== [false, false, false, true])
+    @test first(chn) == 1
+    @test step(chn) == 2
+    @test last(chn) == 999
+    @test size(chn) == (999, 4, 2)
+    @test keys(chn) == ["Param#1", "Param#2", "Param#3", "Param#4"]
+    @test isa(chn[:,1,:], MCMCChain.AbstractChains)
+    @test length(vec(chn[:,1,:].value)) == n_chain * n_iter
+    @test all(collect(skipmissing(chn[:,1,1].value)) .== val[:,1,1])
+    @test all(chn[:,1,2].value .== val[:,1,2])
+    @test all(MCMCChain.indiscretesupport(chn) .== [false, false, false, true])
 end
 
 @testset "function tests" begin
+    # do not test the following functions
+    # - wrtsp
+    # - window2inds (tested above, see getindex)
+    # - 
 
-  # do not test the following functions
-  # - wrtsp
-  # - window2inds (tested above, see getindex)
-  # - 
+    # the following tests only check if the function calls work!
+#    @test MCMCChain.diag_all(rand(100, 2), :weiss, 1, 1, 1) != nothing
+#    @test MCMCChain.diag_all(rand(100, 2), :hangartner, 1, 1, 1) != nothing
+#    @test MCMCChain.diag_all(rand(100, 2), :billingsley, 1, 1, 1) != nothing
 
-  # the following tests only check if the function calls work!
-  @test MCMCChain.diag_all(rand(100, 2), :weiss, 1, 1, 1) != nothing
-  @test MCMCChain.diag_all(rand(100, 2), :hangartner, 1, 1, 1) != nothing
-  @test MCMCChain.diag_all(rand(100, 2), :billingsley, 1, 1, 1) != nothing
-
-  @test isa(discretediag(chn[:,4,:]), MCMCChain.ChainSummary)
-  @test isa(gelmandiag(chn[:,1,:]), MCMCChain.ChainSummary)
-  @test isa(gewekediag(chn[:,1,:]), MCMCChain.ChainSummary)
-  @test isa(heideldiag(chn[:,1,:]), MCMCChain.ChainSummary)
-  @test isa(rafterydiag(chn[:,1,:]), MCMCChain.ChainSummary)
-
-
+    @test isa(discretediag(chn[:,4,:]), MCMCChain.ChainSummary)
+    @test isa(gelmandiag(chn[:,1,:]), MCMCChain.ChainSummary)
+    @test isa(gewekediag(chn[:,1,:]), MCMCChain.ChainSummary)
+    @test isa(heideldiag(chn[:,1,:]), MCMCChain.ChainSummary)
+    @test isa(rafterydiag(chn[:,1,:]), MCMCChain.ChainSummary)
 end

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -34,9 +34,9 @@ end
     # - 
 
     # the following tests only check if the function calls work!
-#    @test MCMCChain.diag_all(rand(100, 2), :weiss, 1, 1, 1) != nothing
-#    @test MCMCChain.diag_all(rand(100, 2), :hangartner, 1, 1, 1) != nothing
-#    @test MCMCChain.diag_all(rand(100, 2), :billingsley, 1, 1, 1) != nothing
+    @test MCMCChain.diag_all(rand(100, 2), :weiss, 1, 1, 1) != nothing
+    @test MCMCChain.diag_all(rand(100, 2), :hangartner, 1, 1, 1) != nothing
+    @test MCMCChain.diag_all(rand(100, 2), :billingsley, 1, 1, 1) != nothing
 
     @test isa(discretediag(chn[:,4,:]), MCMCChain.ChainSummary)
     @test isa(gelmandiag(chn[:,1,:]), MCMCChain.ChainSummary)

--- a/test/missing_tests.jl
+++ b/test/missing_tests.jl
@@ -1,0 +1,26 @@
+using MCMCChain
+using Test
+
+# tests for missing values
+
+@testset "utils" begin
+    x = [1, missing, 3, 2]
+    @test MCMCChain.cummean(x) == [1., 1., 2., 2.]
+end
+
+@testset "stats" begin
+    chn = Chains(randn(1000, 2, 2))
+
+    # call describe without missing values
+    (s1, s2) = describe(devnull, chn)
+
+    # add missing values
+    #chn.value[2,:,:] .= missing
+    chn = Chains(cat(chn.value, ones(1, 2, 2) .* missing, dims = 1))
+
+    # call describe with missing values
+    (m1, m2) = describe(devnull, chn)
+
+    @test all(s1.value[:,1:4,:] .== m1.value[:,1:4,:])
+    @test all(s1.value[:,5,:] .+ 1 .== m1.value[:,5,:])
+end

--- a/test/missing_tests.jl
+++ b/test/missing_tests.jl
@@ -25,8 +25,8 @@ end
 end
 
 @testset "diagnostic functions" begin
-    chn = Chains(randn(1000, 2, 2))
-    
+    chn = Chains(randn(5000, 2, 2))
+
     # Add missing values.
     chn_m = Chains(cat(chn.value, ones(1, 2, 2) .* missing, dims = 1))
 
@@ -35,7 +35,7 @@ end
     
     @test all(gewekediag(chn).value .== gewekediag(chn_m).value)
     @test all(heideldiag(chn).value .== heideldiag(chn_m).value)
-    @test_broken all(rafterydiag(chn).value .== rafterydiag(chn_m).value)
+    @test all(rafterydiag(chn).value .== rafterydiag(chn_m).value)
 
     @test_throws AssertionError discretediag(chn_m)
 end

--- a/test/missing_tests.jl
+++ b/test/missing_tests.jl
@@ -1,7 +1,7 @@
 using MCMCChain
 using Test
 
-# tests for missing values
+# Tests for missing values.
 
 @testset "utils" begin
     x = [1, missing, 3, 2]
@@ -11,16 +11,31 @@ end
 @testset "stats" begin
     chn = Chains(randn(1000, 2, 2))
 
-    # call describe without missing values
+    # Call describe without missing values.
     (s1, s2) = describe(devnull, chn)
 
-    # add missing values
-    #chn.value[2,:,:] .= missing
+    # Add missing values.
     chn = Chains(cat(chn.value, ones(1, 2, 2) .* missing, dims = 1))
 
-    # call describe with missing values
+    # Call describe with missing values.
     (m1, m2) = describe(devnull, chn)
 
     @test all(s1.value[:,1:4,:] .== m1.value[:,1:4,:])
     @test all(s1.value[:,5,:] .+ 1 .== m1.value[:,5,:])
+end
+
+@testset "diagnostic functions" begin
+    chn = Chains(randn(1000, 2, 2))
+    
+    # Add missing values.
+    chn_m = Chains(cat(chn.value, ones(1, 2, 2) .* missing, dims = 1))
+
+    # Currently we only check if diag. functions throw an assertion if a value is missing.
+    @test_throws AssertionError gelmandiag(chn_m)
+    
+    @test all(gewekediag(chn).value .== gewekediag(chn_m).value)
+    @test all(heideldiag(chn).value .== heideldiag(chn_m).value)
+    @test_broken all(rafterydiag(chn).value .== rafterydiag(chn_m).value)
+
+    @test_throws AssertionError discretediag(chn_m)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,3 +14,6 @@ include("plot_test.jl")
 
 # run function tests
 include("diagnostic_tests.jl")
+
+# run tests for missing values
+include("missing_tests.jl")


### PR DESCRIPTION
This PR refactors the Chain type in MCMCChain to allow for missing values and additionally introduces unique symbols which can be used to uniquely index variable.

Related issues #16, TuringLang/Turing.jl#474, TuringLang/Turing.jl#484, TuringLang/Turing.jl#370