### PR TITLE
RFC: Reimplement plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/1av8osv0099nqw8m/branch/master?svg=true)](https://ci.appveyor.com/project/trappmartin/mcmcchain-jl/branch/master)
 [![Coverage Status](https://coveralls.io/repos/github/TuringLang/MCMCChain.jl/badge.svg?branch=master)](https://coveralls.io/github/TuringLang/MCMCChain.jl?branch=master)
 
-Implementation of Julia types for summarizing MCMC simulations and utility functions for diagnostics and visualizations. 
+Implementation of Julia types for summarizing MCMC simulations and utility functions for diagnostics and visualizations.
 
 ## Example
 The following simple example illustrates how to use Chain to visually summarize a MCMC simulation:
 ```julia
 using MCMCChain
-using Plots, StatPlots
+using StatPlots
 
 theme(:ggplot2);
 
@@ -25,7 +25,7 @@ val = hcat(val, rand(1:2, n_iter, 1, n_chain));
 # construct a Chains object
 chn = Chains(val);
 
-# visualize the MCMC simulation results 
+# visualize the MCMC simulation results
 p1 = plot(chn)
 p2 = plot(chn, colordim = :parameter)
 
@@ -41,21 +41,21 @@ Summarize parameters | Summarize chains
 `plot(chn; colordim = :chain)` | `plot(chn; colordim = :parameter)`
 ![p1](https://user-images.githubusercontent.com/7974003/45822242-f0009180-bce2-11e8-8fa0-a97c8732400f.png)  |  ![p2](https://user-images.githubusercontent.com/7974003/45822249-f131be80-bce2-11e8-8dd3-42db7d58abd9.png)
 
- 
+
 
 ## Manual
 ### Chains type
 ```julia
 # construction of a Chains object
 Chains(iterations::Int, params::Int;
-    start = 1, thin = 1, chains = 1, 
+    start = 1, thin = 1, chains = 1,
     names = String[])
 
-# construction of a Chains object using an 
+# construction of a Chains object using an
 # iteration * params * chains
 # array (values).
-Chains(values::Array{T, 3}; 
-    start = 1, thin = 1, chains = 1, 
+Chains(values::Array{T, 3};
+    start = 1, thin = 1, chains = 1,
     names = String[])
 
 # Indexing a Chains object
@@ -95,31 +95,44 @@ rafterydiag(c::AbstractChains; q=0.025, r=0.005, s=0.95, eps=0.001)
 ### Plotting
 ```julia
 # construct a plot
-plot(c::AbstractChains; ptypes = [TracePlot, MixedDensityPlot])
+plot(c::AbstractChains, seriestype = (:traceplot, :mixeddensity))
+plot(c::AbstractChains; ptypes = [TracePlot, MixedDensityPlot]) # deprecated
 plot(c::AbstractChains; [:trace, :mixeddensity]) # deprecated
 
 # construct trace plots
-plot(c::AbstractChains, TracePlot)
+traceplot(c::AbstractChains)
+plot(c::AbstractChains, seriestype = :traceplot)
+plot(c::AbstractChains, TracePlot) # deprecated
 plot(c::AbstractChains, :trace) # deprecated
 
 # construct running average plots
-plot(c::AbstractChains, MeanPlot)
+meanplot(c::AbstractChains)
+plot(c::AbstractChains, seriestype = :meanplot)
+plot(c::AbstractChains, MeanPlot) # deprecated
 plot(c::AbstractChains, :mean) # deprecated
 
 # construct density plots
-plot(c::AbstractChains, DensityPlot)
+density(c::AbstractChains)
+plot(c::AbstractChains, seriestype = :density)
+plot(c::AbstractChains, DensityPlot) # deprecated
 plot(c::AbstractChains, :density) # deprecated
 
 # construct histogram plots
-plot(c::AbstractChains, HistogramPlot)
+histogram(c::AbstractChains)
+plot(c::AbstractChains, seriestype = :histogram)
+plot(c::AbstractChains, HistogramPlot) # deprecated
 plot(c::AbstractChains, :histogram) # deprecated
 
 # construct mixed density plots
-plot(c::AbstractChains, MixedDensityPlot)
+mixeddensity(c::AbstractChains)
+plot(c::AbstractChains, seriestype = :mixeddensity)
+plot(c::AbstractChains, MixedDensityPlot) # deprecated
 plot(c::AbstractChains, :mixeddensity) # deprecated
 
 # construct autocorrelation plots
-plot(c::AbstractChains, AutocorPlot)
+autocorplot(c::AbstractChains)
+plot(c::AbstractChains, seriestype = :autocorplot)
+plot(c::AbstractChains, AutocorPlot) # deprecated
 plot(c::AbstractChains, :autocor) # deprecated
 ```
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,164 +1,110 @@
-export MeanPlot, AutocorPlot, HistogramPlot, DensityPlot, MixedDensityPlot, TracePlot
-export plot
 
-@userplot MeanPlot
-@userplot AutocorPlot
-@userplot HistogramPlot
-@userplot DensityPlot
-@userplot MixedDensityPlot
-@userplot TracePlot
+@shorthands meanplot
+@shorthands autocorplot
+@shorthands mixeddensity
+@shorthands traceplot
 
-supportedplots = [
-                  MeanPlot, 
-                  AutocorPlot, 
-                  HistogramPlot,
-                  DensityPlot,
-                  MixedDensityPlot,
-                  TracePlot
-]
-colorparamters = [:chain, :parameter]
+struct _TracePlot; c; val; end
+struct _MeanPlot; c; val;  end
+struct _DensityPlot; c; val;  end
+struct _HistogramPlot; c; val;  end
+struct _AutocorPlot; lags; val;  end
 
-@recipe function f(p::MeanPlot; colordim = :chain)
-    c, i = p.args
-    seriestype := :line
-    xaxis := "Iteration"
-    yaxis := "Mean"
-    
-    @assert colordim ∈ colorparamters
+# define alias functions for old syntax
+const translationdict = Dict(
+                        :traceplot => _TracePlot,
+                        :meanplot => _MeanPlot,
+                        :density => _DensityPlot,
+                        :histogram => _HistogramPlot,
+                        :autocorplot => _AutocorPlot
+                      )
+
+const supportedplots = push!(collect(keys(translationdict)), :mixeddensity)
+
+@recipe function f(c::AbstractChains, i::Int; colordim = :chain, barbounds = (0, Inf), maxlag = nothing)
+    st = get(plotattributes, :seriestype, :traceplot)
 
     if colordim == :parameter
         title := "Chain $(c.chains[i])"
         labels := c.names
-        c.range, MCMCChain.cummean(c.value[:, :, i])
-    else
+        val = c.value[:, :, i]
+    elseif colordim == :chain
         title := c.names[i]
         labels := map(k -> "Chain $(c.chains[k])", 1:size(c)[3])
-        c.range, MCMCChain.cummean(c.value[:, i, :])
+        val = c.value[:, i, :]
+    else
+        throw(ArgumentError("`colordim` must be one of `:chain` or `:parameter`"))
+    end
+
+    if st == :mixeddensity
+        discrete = MCMCChain.indiscretesupport(c, barbounds)
+        st = (discrete[i] && colordim == :chain) ? :histogram : :density
+        seriestype := st
+    end
+
+    if st == :autocorplot
+        lags = 0:(maxlag === nothing ? round(Int, 10 * log10(length(c.range))) : maxlag)
+        ac = MCMCChain.autocor(c, lags=collect(lags))
+        val = colordim == :parameter ? ac.value[:, :, i]' : ac.value[i, :, :]
+        _AutocorPlot(lags, val)
+    elseif st ∈ supportedplots
+        translationdict[st](c, val)
+    else
+        c.range, val
     end
 end
 
-@recipe function f(p::AutocorPlot; maxlag = nothing, colordim = :chain)
-    c, i = p.args
-    lags = 0:(maxlag === nothing ? round(Int, 10 * log10(length(c.range))) : maxlag)
-    ac = MCMCChain.autocor(c, lags=collect(lags))
-    xaxis := "Lag"
-    yaxis := "Autocorrelation"
-
-    @assert colordim ∈ colorparamters
-    if colordim == :parameter
-        title := "Chain $(c.chains[i])"
-        labels := c.names
-        lags, ac.value[:, :, i]'
-    else
-        title := c.names[i]
-        labels := map(k -> "Chain $(c.chains[k])", 1:size(c)[3])
-        lags, ac.value[i, :, :]
-    end
+@recipe function f(p::_DensityPlot)
+    xaxis --> "Sample value"
+    yaxis --> "Density"
+    [collect(skipmissing(p.val[:,k])) for k in axes(p.val, 2)]
 end
 
-@recipe function f(p::HistogramPlot; colordim = :chain)
-    c, i = p.args
-    seriestype := :histogram
-    xaxis := "Sample value"
-    yaxis := "Frequency"
-    fillalpha := 0.7
-
-    @assert colordim ∈ colorparamters
-    
-    if colordim == :parameter
-        title := "Chain $(c.chains[i])"
-        labels := c.names
-        nvars = size(c)[2]
-        [collect(skipmissing(c.value[:, k, i])) for k in 1:nvars]
-    else
-        title := c.names[i]
-        labels := map(k -> "Chain $(c.chains[k])", 1:size(c)[3])
-        nchains = size(c)[3]
-        [collect(skipmissing(c.value[:, i, k])) for k in 1:nchains]
-    end
+@recipe function f(p::_HistogramPlot)
+    xaxis --> "Sample value"
+    yaxis --> "Frequency"
+    fillalpha --> 0.7
+    [collect(skipmissing(p.val[:,k])) for k in axes(p.val, 2)]
 end
 
-@recipe function f(p::DensityPlot; colordim = :chain)
-    c, i = p.args
-    seriestype := :density
-    xaxis := "Sample value"
-    yaxis := "Density"
-    
-    @assert colordim ∈ colorparamters
-    
-    if colordim == :parameter
-        title := "Chain $(c.chains[i])"
-        labels := c.names
-        nvars = size(c)[2]
-        [collect(skipmissing(c.value[:, k, i])) for k in 1:nvars]
-    else
-        title := c.names[i]
-        labels := map(k -> "Chain $(c.chains[k])", 1:size(c)[3])
-        nchains = size(c)[3]
-        [collect(skipmissing(c.value[:, i, k])) for k in 1:nchains]
-    end
+@recipe function f(p::_MeanPlot)
+    seriestype := :path
+    xaxis --> "Iteration"
+    yaxis --> "Mean"
+    p.c.range, MCMCChain.cummean(p.val)
 end
 
-@recipe function f(p::TracePlot; colordim = :chain)
-    c, i = p.args
-    seriestype := :line
-    xaxis := "Iteration"
-    yaxis := "Sample value"
-    @assert colordim ∈ colorparamters
-    
-    if colordim == :parameter
-        title := "Chain $(c.chains[i])"
-        labels := c.names
-        c.range, c.value[:, :, i]
-    else
-        title := c.names[i]
-        labels := map(k -> "Chain $(c.chains[k])", 1:size(c)[3])
-        c.range, c.value[:, i, :]
-    end
+@recipe function f(p::_AutocorPlot)
+    seriestype := :path
+    xaxis --> "Lag"
+    yaxis --> "Autocorrelation"
+    p.lags, p.val
 end
 
-@recipe function f(p::MixedDensityPlot; barbounds = (0, Inf), colordim = :chain)
-    c, i = p.args
-    discrete = MCMCChain.indiscretesupport(c, barbounds)
-    
-    seriestype := :density
-    xaxis := "Sample value"
-    yaxis := "Density"
-    
-    @assert colordim ∈ colorparamters
-    
-    if colordim == :parameter
-        title := "Chain $(c.chains[i])"
-        labels := c.names
-        nvars = size(c)[2]
-        [collect(skipmissing(c.value[:, k, i])) for k in 1:nvars]
-    else
-        seriestype := discrete[i] ? :histogram : :density
-        yaxis := discrete[i] ? "Frequency" : "Density"
-        fillalpha := discrete[i] ? 0.7 : 1.0
-        title := c.names[i]
-        labels := map(k -> "Chain $(c.chains[k])", 1:size(c)[3])
-        nchains = size(c)[3]
-        [collect(skipmissing(c.value[:, i, k])) for k in 1:nchains]
-    end
+@recipe function f(p::_TracePlot)
+    seriestype := :path
+    xaxis --> "Iteration"
+    yaxis --> "Sample value"
+    p.c.range, p.val
 end
 
 @recipe function f(c::MCMCChain.AbstractChains;
-                   ptypes = [TracePlot, MixedDensityPlot], 
-                   width = 500, 
+                   width = 500,
                    height = 250,
                    colordim = :chain
                   )
 
-    # sanity checks
+    ptypes = get(plotattributes, :seriestype, (:traceplot, :mixeddensity))
+
+    # sanity check
+    ptypes = ptypes isa AbstractVector || ptypes isa Tuple ? ptypes : (ptypes,)
     @assert all(map(ptype -> ptype ∈ supportedplots, ptypes))
-    @assert colordim ∈ colorparamters
 
     nrows, nvars, nchains = size(c.value)
     ntypes = length(ptypes)
     N = colordim == :chain ? nvars : nchains
     layout := (N, ntypes)
-    size := (ntypes*width, N*height)
+    size --> (ntypes*width, N*height)
     indices = reshape(1:N*ntypes, ntypes, N)'
 
     legend --> false
@@ -168,69 +114,21 @@ end
             @series begin
                 subplot := indices[i, j]
                 colordim := colordim
-                ptype([c, i])
+                seriestype := ptype
+                c, i
             end
         end
     end
 end
 
-"""
-    plot(c::AbstractChains, ptype::DataType)
-
-Plot the summary of a MCMC simulation stored in `c` by using the plotting type specified
-in ptype.
-
-Optional Arguments:
-- `width = 500`
-- `height = 250`
-- `colordim = :chain` ... either :chain or :parameter
-
-"""
-@recipe function f(c::AbstractChains,
-              ptype::DataType;
-              width = 500,
-              height = 250,
-              colordim = :chain
-             )
-    
-    @assert ptype ∈ supportedplots
-    @assert colordim ∈ colorparamters
-    
-    nrows, nvars, nchains = size(c.value)
-    N = colordim == :chain ? nvars : nchains
-    layout := (N, 1)
-    size := (width, N*height)
-    indices = reshape(1:N, 1, N)'
-
-    legend --> false
-
-    for i in 1:N
-        @series begin
-            subplot := indices[i, 1]
-            colordim := colordim
-            ptype([c, i])
-        end
-    end
-end
-
-# define alias functions for old syntax
-translationdict = Dict(
-                        :trace => TracePlot,
-                        :mean => MeanPlot,
-                        :density => DensityPlot,
-                        :histogram => HistogramPlot,
-                        :mixeddensity => MixedDensityPlot,
-                        :autocor => AutocorPlot
-                      )
-
 function plot(c::AbstractChains, psyms::Vector{Symbol}; args...)
     @assert all(map(psym -> haskey(translationdict, psym), psyms))
-    @warn "This syntax is deprecated, please use plot(c; ptypes = [TracePlot]) instead."
-    return plot(c; ptypes = map(psym -> translationdict[psym], psyms))
+    @warn "This syntax is deprecated, please use plot(c; seriestype = $psyms) instead."
+    return plot(c; seriestype = map(psym -> translationdict[psym], psyms))
 end
 
 function plot(c::AbstractChains, psym::Symbol; args...)
     @assert haskey(translationdict, psym)
-    @warn "This syntax is deprecated, please use plot(c, $(translationdict[psym])) instead"
-    return plot(c, translationdict[psym]; args...)
+    @warn "This syntax is deprecated, please use plot(c, seriestype = $(translationdict[psym])) instead"
+    return plot(c; seriestype = psym, args...)
 end

--- a/test/plot_test.jl
+++ b/test/plot_test.jl
@@ -1,5 +1,4 @@
 using Test
-using Plots
 using StatPlots
 using MCMCChain
 
@@ -19,7 +18,7 @@ ps_trace = traceplot(chn, 1)
 ps_mean = meanplot(chn, 1)
 @test isa(ps_mean, Plots.Plot)
 
-ps_density = densityplot(chn, 1)
+ps_density = density(chn, 1)
 @test isa(ps_density, Plots.Plot)
 
 ps_autocor = autocorplot(chn, 1)
@@ -27,10 +26,10 @@ ps_autocor = autocorplot(chn, 1)
 
 #ps_contour = plot(chn, :contour)
 
-ps_hist = histogramplot(chn, 1)
+ps_hist = histogram(chn, 1)
 @test isa(ps_hist, Plots.Plot)
 
-ps_mixed = mixeddensityplot(chn, 1)
+ps_mixed = mixeddensity(chn, 1)
 @test isa(ps_mixed, Plots.Plot)
 
 # plotting combinations
@@ -39,5 +38,5 @@ ps_trace_mean = plot(chn)
 
 savefig("demo-plot.png")
 
-ps_mixed_auto = plot(chn, ptypes = [MixedDensityPlot, AutocorPlot])
+ps_mixed_auto = plot(chn, seriestype = (:mixeddensity, :autocorplot))
 @test isa(ps_mixed_auto, Plots.Plot)


### PR DESCRIPTION
As discussed on Slack. Here's the rationale (copied from the discussion). 

Right now the code is elegant and makes full use of the recipes API, but it’s just a little at odds with normal Plots logic. In two respects mainly: 

1. You have `densityplot` and `histogramplot` names, but in fact they’re just `density` and `histogram` that accepts a `Chain` (and adds some labels). The Plot idea is to use the same logic throughout, so you won’t have to remember so many arbitrary things, so ideally you should just write `histogram(myChain)`. But that’s a little tricky as density and histogram are `series recipes` and you’ve implemented everything as `user recipes`.

2. You have the concept of `ptype`, which is exactly what we in Plots terminology call `seriestype`. So I’d suggest reimplementing using the `seriestype` interface. It’s tricky in practice because you want each chain to have a different color, and seriestypes don’t normally do that. 

3. One way of doing this is slightly unelegant by simply querying the seriestype argument and then using `if...else` loops. I've used object dispatch and recipes instead where possible, for code cleanliness, but it turned out to not be completely possible for AutocorPlot. I'm not really happy about that, but there you are. It could all be reimplemented as the if-else block instead.

3. I've also cleaned duplications from the code.



cc @trappmartin