### PR TITLE
Corner plot - close #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,44 +96,29 @@ rafterydiag(c::AbstractChains; q=0.025, r=0.005, s=0.95, eps=0.001)
 ```julia
 # construct a plot
 plot(c::AbstractChains, seriestype = (:traceplot, :mixeddensity))
-plot(c::AbstractChains; ptypes = [TracePlot, MixedDensityPlot]) # deprecated
-plot(c::AbstractChains; [:trace, :mixeddensity]) # deprecated
 
 # construct trace plots
-traceplot(c::AbstractChains)
 plot(c::AbstractChains, seriestype = :traceplot)
-plot(c::AbstractChains, TracePlot) # deprecated
-plot(c::AbstractChains, :trace) # deprecated
+# or for all seriestypes use the alternative shorthand syntax
+traceplot(c::AbstractChains)
 
 # construct running average plots
 meanplot(c::AbstractChains)
-plot(c::AbstractChains, seriestype = :meanplot)
-plot(c::AbstractChains, MeanPlot) # deprecated
-plot(c::AbstractChains, :mean) # deprecated
 
 # construct density plots
 density(c::AbstractChains)
-plot(c::AbstractChains, seriestype = :density)
-plot(c::AbstractChains, DensityPlot) # deprecated
-plot(c::AbstractChains, :density) # deprecated
 
 # construct histogram plots
 histogram(c::AbstractChains)
-plot(c::AbstractChains, seriestype = :histogram)
-plot(c::AbstractChains, HistogramPlot) # deprecated
-plot(c::AbstractChains, :histogram) # deprecated
 
 # construct mixed density plots
 mixeddensity(c::AbstractChains)
-plot(c::AbstractChains, seriestype = :mixeddensity)
-plot(c::AbstractChains, MixedDensityPlot) # deprecated
-plot(c::AbstractChains, :mixeddensity) # deprecated
 
 # construct autocorrelation plots
 autocorplot(c::AbstractChains)
-plot(c::AbstractChains, seriestype = :autocorplot)
-plot(c::AbstractChains, AutocorPlot) # deprecated
-plot(c::AbstractChains, :autocor) # deprecated
+
+# make a cornerplot (requires StatPlots) of parameters in a Chain:
+corner(c::AbstractChains, parameters = [:A, :B])
 ```
 
 ## License Notice

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ mixeddensity(c::AbstractChains)
 autocorplot(c::AbstractChains)
 
 # make a cornerplot (requires StatPlots) of parameters in a Chain:
-corner(c::AbstractChains, parameters = [:A, :B])
+corner(c::AbstractChains, [:A, :B])
 ```
 
 ## License Notice

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -22,6 +22,8 @@ const translationdict = Dict(
 
 const supportedplots = push!(collect(keys(translationdict)), :mixeddensity)
 
+@recipe f(c::AbstractChains, s::Symbol) = c, indexin([s], keys(c))
+
 @recipe function f(c::AbstractChains, i::Int; colordim = :chain, barbounds = (0, Inf), maxlag = nothing)
     st = get(plotattributes, :seriestype, :traceplot)
 
@@ -95,6 +97,7 @@ end
 end
 
 @recipe function f(c::MCMCChain.AbstractChains;
+                   parameters = Symbol[],
                    width = 500,
                    height = 250,
                    colordim = :chain
@@ -127,7 +130,8 @@ end
             end
         end
     else
-        Corner(c)
+        params = isempty(parameters) ? Symbol.(keys(c)) : Symbol.(parameters)
+        Corner(c, params)
     end
 end
 
@@ -143,12 +147,14 @@ function plot(c::AbstractChains, psym::Symbol; args...)
     return plot(c; seriestype = psym, args...)
 end
 
-struct Corner; c; end
+struct Corner
+    c
+    parameters
+end
 
 @recipe function f(corner::Corner)
-    syms = keys(corner.c)
-    label --> permutedims(syms)
+    label --> permutedims(corner.parameters)
     compact --> true
-    size --> (800, 800)
-    RecipesBase.recipetype(:cornerplot, reduce(hcat, corner.c[s] for s in Symbol.(syms)))
+    size --> (600, 600)
+    RecipesBase.recipetype(:cornerplot, reduce(hcat, corner.c[s] for s in corner.parameters))
 end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -125,7 +125,6 @@ end
         for (j, ptype) in enumerate(ptypes)
             for (i, par) in enumerate(parameters)
                 @series begin
-                    @show parameters
                     subplot := indices[i, j]
                     colordim := colordim
                     seriestype := ptype

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -137,3 +137,12 @@ function plot(c::AbstractChains, psym::Symbol; args...)
     @warn "This syntax is deprecated, please use plot(c, seriestype = $(translationdict[psym])) instead"
     return plot(c; seriestype = psym, args...)
 end
+
+@userplot ChainCorner
+@recipe function f(cs::ChainCorner)
+    chain, syms = cs.args
+
+    label --> permutedims(syms)
+    compact --> true
+    RecipesBase.recipetype(:cornerplot, reduce(hcat, chain[s] for s in syms))
+end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -3,6 +3,7 @@
 @shorthands autocorplot
 @shorthands mixeddensity
 @shorthands traceplot
+@shorthands corner
 
 struct _TracePlot; c; val; end
 struct _MeanPlot; c; val;  end


### PR DESCRIPTION
This works now in the sense that
```julia
using Turing, StatPlots, MCMCChain
@model f(x) = begin
          A ~ Normal(0,1)
          B ~ Normal(0,1)
          C ~ Normal(0,1)
          x ~ Normal(0,1)
       end
chain = sample(f(1), HMC(500,0.01,1))
chaincorner(chain, [:A, :B, :C])
```
gives
<img width="580" alt="skaermbillede 2019-01-17 kl 21 29 15" src="https://user-images.githubusercontent.com/8429802/51347236-d3f9da80-1a9f-11e9-9943-1dff9c4787c1.png">

But, I really think we should align the syntax with the rest of the plotting syntax you have here. I can't 100% see the design of that so would be good with input. @trappmartin @cpfiffer 

Also, this requires a change in StatPlots so will require StatPlots 0.9, and will only work on julia-1.0+ 
That is a common issue with advanced recipes.

Finally, shouldn't the default size of those points in cornerplot not be smaller? :-O