### PR TITLE
Fixed isnothing not defined error

### DIFF
--- a/src/chains.jl
+++ b/src/chains.jl
@@ -76,7 +76,10 @@ function Chains(
                ) where {T<:Union{Real, Missing}}
 
     Chains(
-        reshape(value, size(value, 1), size(value, 2), 1),
+        convert(
+            Array{Union{Missing, T}, 3},
+            reshape(value, size(value, 1), size(value, 2), 1)
+        ),
         start=start,
         thin=thin,
         names=names,

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -99,7 +99,7 @@ end
 @recipe function f(c::MCMCChain.AbstractChains, parameters::AbstractVector{Symbol}; colordim = :chain)
     colordim != :chain && error("Symbol names are interpreted as parameter names, only compatible with `colordim = :chain`")
     ret = indexin(parameters, Symbol.(keys(c)))
-    any(isnothing, ret) && error("Parameter not found")
+    any(y -> y == nothing, ret) && error("Parameter not found")
     c, Int.(ret)
 end
 

--- a/test/plot_test.jl
+++ b/test/plot_test.jl
@@ -1,5 +1,5 @@
 using Test
-using StatPlots
+using StatsPlots
 using MCMCChain
 
 n_iter = 500

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Pkg
 # add packages
 to_add = [
     PackageSpec(name="Plots"),
-    PackageSpec(name="StatPlots"),
+    PackageSpec(name="StatsPlots"),
 ]
 
 Pkg.add(to_add)


### PR DESCRIPTION
I was getting an undefined error for the `isnothing` function in `corner(chain, syms)` on Julia 1.0, so I changed it to an anonymous function. Anyone see any obvious issues here?