### PR TITLE
Revert PrettyTables=3 compat, add a test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "Chain types and utility functions for MCMC simulations."
-version = "7.2.1"
+version = "7.2.2"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
@@ -40,7 +40,7 @@ MCMCDiagnosticTools = "0.3"
 MLJModelInterface = "0.3.5, 0.4, 1.0"
 NaturalSort = "1"
 OrderedCollections = "1.4"
-PrettyTables = "0.9, 0.10, 0.11, 0.12, 1, 2, 3"
+PrettyTables = "0.9, 0.10, 0.11, 0.12, 1, 2"
 Random = "<0.0.1, 1"
 RecipesBase = "0.7, 0.8, 1.0"
 Statistics = "<0.0.1, 1"

--- a/test/display_tests.jl
+++ b/test/display_tests.jl
@@ -1,0 +1,3 @@
+@testset "describe" begin
+    @test describe(Chains(rand(10, 3, 1))) isa Any
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,9 @@ Random.seed!(0)
     println("Plotting")
     @time include("plot_test.jl")
 
+    println("Display")
+    @time include("display_tests.jl")
+
     # run function tests
     println("Diagnostics")
     @time include("diagnostic_tests.jl")


### PR DESCRIPTION
PrettyTables=3 is not compatible with MCMCChains.

```julia
julia> describe(Chains(rand(10, 3, 1)))
Chains MCMC chain (10×3×1 Array{Float64, 3}):

Iterations        = 1:1:10
Number of chains  = 1
Samples per chain = 10
parameters        = param_1, param_2, param_3

ERROR: UndefVarError: `ft_printf` not defined in `PrettyTables`
Suggestion: check for spelling errors or missing imports.
Stacktrace:
 [1] show(io::Base.TTY, ::MIME{Symbol("text/plain")}, df::ChainDataFrame{@NamedTuple{…}})
   @ MCMCChains ~/ppl/MCMCChains.jl/src/summarize.jl:28
 [2] describe(io::Base.TTY, chains::Chains{…}; q::Vector{…}, etype::Symbol, kwargs::@Kwargs{})
   @ MCMCChains ~/ppl/MCMCChains.jl/src/stats.jl:191
 [3] describe(io::Base.TTY, chains::Chains{Float64, AxisArrays.AxisArray{…}, Missing, @NamedTuple{…}, @NamedTuple{}})
   @ MCMCChains ~/ppl/MCMCChains.jl/src/stats.jl:180
 [4] describe(chains::Chains{Float64, AxisArrays.AxisArray{…}, Missing, @NamedTuple{…}, @NamedTuple{}}; kwargs::@Kwargs{})
   @ MCMCChains ~/ppl/MCMCChains.jl/src/stats.jl:199
 [5] top-level scope
   @ REPL[10]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

In principle https://github.com/TuringLang/MCMCChains.jl/pull/485 should not have been merged, but unfortunately we didn't have any tests that caught the error, so CI passed. This PR therefore also adds a test so that we don't run into this situation again.